### PR TITLE
Prevent leaving zombie process on exit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/main.js
+++ b/main.js
@@ -80,6 +80,7 @@ function createMainWindow() {
 
   mainWindow.on('closed', () => {
     mainWindow = null;
+    app.quit();
   });
 
   mainWindow.once('ready-to-show', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "vi1b",
+  "name": "visual_interactor",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vi1b",
+      "name": "visual_interactor",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
Fixed: zombie process left behind when closing the main window. Added gitignore for preventing node_modules versioning.